### PR TITLE
Enable building `llfree` with stable toolchain in no-std environments

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -1,5 +1,7 @@
 use std::env;
+use std::num::NonZeroUsize;
 use std::process::Command;
+use std::thread::available_parallelism;
 
 fn main() {
     if env::var("CARGO_FEATURE_LLC").is_ok() {
@@ -12,6 +14,10 @@ fn main() {
         let output = Command::new("make")
             .arg(format!("DEBUG={}", is_debug as usize))
             .arg(format!("BUILDDIR={outdir}"))
+            .arg(format!(
+                "-j{}",
+                available_parallelism().unwrap_or(NonZeroUsize::MIN)
+            ))
             .arg("-C")
             .arg(&c_project_dir)
             .arg(format!("{outdir}/libllc.a"))

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,6 @@
 #![feature(allocator_api)]
 #![feature(c_size_t)]
 #![feature(let_chains)]
-#![feature(pointer_is_aligned_to)]
 // Don't warn for compile-time checks
 #![allow(clippy::assertions_on_constants)]
 #![allow(clippy::redundant_pattern_matching)]
@@ -179,9 +178,9 @@ impl MetaData<'_> {
         self.local.len() >= m.local
             && self.trees.len() >= m.trees
             && self.lower.len() >= m.lower
-            && self.local.as_ptr().is_aligned_to(align_of::<Align>())
-            && self.trees.as_ptr().is_aligned_to(align_of::<Align>())
-            && self.lower.as_ptr().is_aligned_to(align_of::<Align>())
+            && self.local.as_ptr().align_offset(align_of::<Align>()) == 0
+            && self.trees.as_ptr().align_offset(align_of::<Align>()) == 0
+            && self.lower.as_ptr().align_offset(align_of::<Align>()) == 0
             && !overlap(self.local.as_ptr_range(), self.trees.as_ptr_range())
             && !overlap(self.trees.as_ptr_range(), self.lower.as_ptr_range())
             && !overlap(self.lower.as_ptr_range(), self.local.as_ptr_range())

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,7 +5,6 @@
 // Unstable (but useful) features
 #![feature(allocator_api)]
 #![feature(c_size_t)]
-#![feature(let_chains)]
 // Don't warn for compile-time checks
 #![allow(clippy::assertions_on_constants)]
 #![allow(clippy::redundant_pattern_matching)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,6 @@
 // Disable standard library
 #![no_std]
 // Unstable (but useful) features
-#![feature(array_windows)]
 #![feature(allocator_api)]
 #![feature(c_size_t)]
 #![feature(let_chains)]
@@ -346,7 +345,7 @@ mod test {
         frames.sort_unstable();
 
         // Check that the same frame was not allocated twice
-        for &[a, b] in frames.array_windows() {
+        for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
             assert_ne!(a, b);
             assert!(a < FRAMES && b < FRAMES);
         }
@@ -406,7 +405,7 @@ mod test {
 
         // Check that the same frame was not allocated twice
         frames.sort_unstable();
-        for &[a, b] in frames.array_windows() {
+        for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
             assert_ne!(a, b);
             assert!(a < FRAMES && b < FRAMES);
         }
@@ -426,7 +425,7 @@ mod test {
         alloc.validate();
         // Check that the same frame was not allocated twice
         frames.sort_unstable();
-        for &[a, b] in frames.array_windows() {
+        for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
             assert_ne!(a, b);
             assert!(a < FRAMES && b < FRAMES);
         }
@@ -465,7 +464,7 @@ mod test {
             warn!("check...");
             // Check that the same frame was not allocated twice
             frames.sort_unstable();
-            for &[a, b] in frames.array_windows() {
+            for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
                 assert_ne!(a, b);
                 assert!(a < FRAMES && b < FRAMES);
             }
@@ -484,7 +483,7 @@ mod test {
             warn!("check...");
             // Check that the same frame was not allocated twice
             frames.sort_unstable();
-            for &[a, b] in frames.array_windows() {
+            for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
                 assert_ne!(a, b);
                 assert!(a < FRAMES && b < FRAMES);
             }
@@ -540,7 +539,7 @@ mod test {
         frames.sort_unstable();
 
         // Check that the same frame was not allocated twice
-        for &[a, b] in frames.array_windows() {
+        for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
             assert_ne!(a, b);
             assert!(a < FRAMES && b < FRAMES);
         }
@@ -612,7 +611,7 @@ mod test {
 
         // Check that the same frame was not allocated twice
         frames.sort_unstable();
-        for &[a, b] in frames.array_windows() {
+        for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
             assert_ne!(a, b);
             assert!(a < FRAMES && b < FRAMES);
         }
@@ -648,7 +647,7 @@ mod test {
 
         // Check that the same frame was not allocated twice
         frames.sort_unstable();
-        for &[a, b] in frames.array_windows() {
+        for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
             assert_ne!(a, b);
             assert!(a < FRAMES && b < FRAMES);
         }
@@ -691,7 +690,7 @@ mod test {
 
         // Check that the same frame was not allocated twice
         frames.sort_unstable();
-        for &[a, b] in frames.array_windows() {
+        for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
             assert_ne!(a, b);
             assert!(a < FRAMES && b < FRAMES);
         }
@@ -736,7 +735,7 @@ mod test {
 
         // Check that the same frame was not allocated twice
         frames.sort_unstable();
-        for &[a, b] in frames.array_windows() {
+        for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
             assert_ne!(a, b);
             assert!(a < FRAMES && b < FRAMES);
         }
@@ -796,7 +795,7 @@ mod test {
 
         // Check that the same frame was not allocated twice
         frames.sort_unstable();
-        for &[a, b] in frames.array_windows() {
+        for (a, b) in frames.windows(2).map(|p| (p[0], p[1])) {
             assert_ne!(a, b);
             assert!(a < FRAMES && b < FRAMES);
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,6 @@
 // Disable standard library
 #![no_std]
 // Unstable (but useful) features
-#![feature(int_roundings)]
 #![feature(array_windows)]
 #![feature(allocator_api)]
 #![feature(c_size_t)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,8 +3,8 @@
 // Disable standard library
 #![no_std]
 // Unstable (but useful) features
-#![feature(allocator_api)]
-#![feature(c_size_t)]
+#![cfg_attr(feature = "std", feature(allocator_api))]
+#![cfg_attr(feature = "llc", feature(c_size_t))]
 // Don't warn for compile-time checks
 #![allow(clippy::assertions_on_constants)]
 #![allow(clippy::redundant_pattern_matching)]

--- a/core/src/trees.rs
+++ b/core/src/trees.rs
@@ -134,9 +134,13 @@ impl<'a> Trees<'a> {
     ) -> Result<usize> {
         // There has to be enough space for the current allocation
         let start = (start + self.entries.len()) as isize;
-        for i in offset as isize..len as isize {
+        for i in offset..len {
             // Alternating between before and after this entry
-            let off = if i % 2 == 0 { i / 2 } else { -i.div_ceil(2) };
+            let off = if i % 2 == 0 {
+                (i / 2) as isize
+            } else {
+                -(i.div_ceil(2) as isize)
+            };
             let i = (start + off) as usize % self.entries.len();
             match f(i) {
                 Err(Error::Memory) => {}


### PR DESCRIPTION
Remove use of nightly features where possible, and enable the remaining ones only where needed. This allows using no nightly features when the `std` crate feature is disabled, which in turn means it can be built with the stable toolchain, e.g:

```
cargo +stable build --package llfree --no-default-features
```

Additionally, build `llc` with all available cores (i.e. using `make -j $NCPUS`)